### PR TITLE
Support pre-defining resource sets on initialisation

### DIFF
--- a/lib/translator.js
+++ b/lib/translator.js
@@ -13,6 +13,7 @@ function arrayify(value) {
 
 function Translator(options) {
   options = _.extend({
+    resources: {},
     backend: require('./backends/fs'),
     fallbackLang: ['en'],
     fallbackNamespace: ['default']
@@ -44,12 +45,12 @@ Translator.prototype.on = function (event, handler) {
 };
 
 Translator.prototype.reload = function () {
-  this.datastore = {};
+  this.datastore = _.cloneDeep(this.options.resources);
   this.options.backend.load(this.options, function (err, data) {
     if (err) {
       throw err;
     } else {
-      this.datastore = data;
+      _.merge(this.datastore, data);
       this.emit('ready');
     }
   }.bind(this));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "eslint ./lib",
-    "unit": "mocha --require test/helpers --recursive",
+    "unit": "mocha --require test/helpers --recursive ./test/spec",
     "test": "npm run lint && npm run unit"
   },
   "repository": {

--- a/test/spec/spec.translator.js
+++ b/test/spec/spec.translator.js
@@ -119,6 +119,32 @@ describe('Translator', function () {
 
     });
 
+    describe('pre-defined resources', function () {
+
+      beforeEach(function () {
+        translator = new Translator({
+          backend: backend,
+          resources: require('../stubs/predefined')
+        });
+        backend.load.yield(null, require('../stubs/simple'));
+      });
+
+      it('includes translations from the pre-defined resources', function () {
+        translator.translate('predef').should.equal('true');
+        translator.translate('predef', { lang: 'fr' }).should.equal('vrai');
+      });
+
+      it('includes translations from resources loaded from backend', function () {
+        translator.translate('name.first', { lang: 'fr' }).should.equal('Jean');
+        translator.translate('name.first').should.equal('John');
+      });
+
+      it('does not mutate the pre-defined resources', function () {
+        require('../stubs/predefined').en.default.should.not.have.property('name');
+      });
+
+    });
+
   });
 
 });

--- a/test/stubs/predefined.js
+++ b/test/stubs/predefined.js
@@ -1,0 +1,12 @@
+module.exports = {
+    en: {
+        default: {
+            predef: 'true'
+        }
+    },
+    fr: {
+        default: {
+            predef: 'vrai'
+        }
+    }
+};


### PR DESCRIPTION
This means that if a module wishes to load shared resources (such as from an external dependency) then they can easily do so.