### PR TITLE
Allow language parameter to be passed as a string or array

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var i18n = require('i18n-future');
 
 // i18n fires a "ready" event when it is done loading resources
 i18n.on('ready', function () {
-    i18n.translate('name.first', { lang: 'en' });
+    i18n.translate('name.first', 'fr');
 });
 ```
 
@@ -85,12 +85,16 @@ app.use(i18n);
 
 The translate method takes an additional options object with parameters for language and namespace to be loaded. This applies to both standalone and express middleware options (although in the middleware case any language option will overwrite the accepts header as a language preference)
 
+If the options are set to an array or a string, then this will be used as the language.
+
 ```javascript
 // simple language option
-i18n.translate('greeting', { lang: 'fr' });
+i18n.translate('greeting', 'fr');
 // multiple langauge options as an array
-i18n.translate('greeting', { lang: ['en-GB', 'en'] });
+i18n.translate('greeting', ['en-GB', 'en']);
 ```
+
+If multiple langauges are passed, then the first matching language will be used. For example: `i18n.translate('greeting', ['en-GB', 'en']);` will look for `en-GB` first, and fall back to `en` only if a translation for `en-GB` is not found.
 
 ```javascript
 // simple namespace option

--- a/examples/standalone/index.js
+++ b/examples/standalone/index.js
@@ -1,9 +1,9 @@
 var i18n = require('i18n-future')();
 
 i18n.on('ready', function () {
-    var en = i18n.translate('greeting', { lang: 'en' });
+    var en = i18n.translate('greeting', 'en');
     console.log('English:', en);
-    var fr = i18n.translate('greeting', { lang: 'fr' });
+    var fr = i18n.translate('greeting', 'fr');
     console.log('French:', fr);
     var def = i18n.translate('greeting');
     console.log('Default fallback:', def);

--- a/lib/translator.js
+++ b/lib/translator.js
@@ -4,11 +4,7 @@ var util = require('util'),
 var _ = require('lodash');
 
 function arrayify(value) {
-  if (value) {
-    return _.isArray(value) ? value : [value];
-  } else {
-    return [];
-  }
+  return [].concat(value || []);
 }
 
 function Translator(options) {
@@ -59,6 +55,12 @@ Translator.prototype.reload = function () {
 Translator.prototype.translate = function (keys, options) {
   options = options || {};
 
+  if (typeof options === 'string' || Array.isArray(options)) {
+    options = {
+      lang: options
+    };
+  }
+
   var langs = this.getLanguages(options),
       namespaces = this.getNamespaces(options);
 
@@ -78,7 +80,7 @@ Translator.prototype.getLanguages = function (options) {
   options = options || {};
   var langs = _.clone(this.options.fallbackLang) || [];
   options.lang = arrayify(options.lang);
-  _.each(options.lang, function (lng) {
+  _.eachRight(options.lang, function (lng) {
     if (lng.indexOf('-')) {
       langs.unshift(lng.split('-')[0]);
     }

--- a/test/spec/spec.translator.js
+++ b/test/spec/spec.translator.js
@@ -65,6 +65,14 @@ describe('Translator', function () {
         translator.translate('name.first', { lang: 'fr' }).should.equal('Jean');
       });
 
+      it('handles a lang passed as a string argument', function () {
+        translator.translate('name.first', 'fr').should.equal('Jean');
+      });
+
+      it('handles a lang passed as an array argument', function () {
+        translator.translate('name.first', ['fr', 'de']).should.equal('Jean');
+      });
+
       it('falls back to less specific language if a specific language is provided', function () {
         translator.translate('name.first', { lang: 'en-GB' }).should.equal('John');
         translator.translate('name.last', { lang: 'en-GB' }).should.equal('Smith');
@@ -72,7 +80,14 @@ describe('Translator', function () {
 
       it('supports a list of languages being provided', function () {
         translator.translate('name.first', { lang: ['de'] }).should.equal('Franz');
+        translator.translate('name.first', { lang: ['de', 'fr'] }).should.equal('Franz');
+        translator.translate('name.first', ['de', 'fr']).should.equal('Franz');
+      });
+
+      it('falls through if a translation is not available for a language', function () {
+        translator.translate('name.first', { lang: ['de'] }).should.equal('Franz');
         translator.translate('name.first', { lang: ['es', 'de'] }).should.equal('Franz');
+        translator.translate('name.first', ['es', 'de']).should.equal('Franz');
       });
 
     });


### PR DESCRIPTION
Setting the language is a far more common use case than setting the namespace, so make it simple.